### PR TITLE
Fix: CSS Overflow & Misalignment

### DIFF
--- a/html/style/ghCore.css
+++ b/html/style/ghCore.css
@@ -115,7 +115,7 @@ ul.plain li {
 	width: 33%;
 }
 #topCenterColumn {
-	width: 33%;
+	width: 34%;
 	text-align: center;
 }
 #topRightColumn {

--- a/html/style/ghCore.css
+++ b/html/style/ghCore.css
@@ -159,7 +159,7 @@ ul.plain li {
 	width: 100%;
 	border-top-style: solid;
 	border-top-width: 1px;
-	padding: 2px;
+	padding: 2px 0;
 }
 .ghWidgetBox {
 	position: relative;

--- a/html/style/ghCore.css
+++ b/html/style/ghCore.css
@@ -120,6 +120,7 @@ ul.plain li {
 }
 #topRightColumn {
 	width: 33%;
+	float: right;
 }
 .wrapper {
 	min-width: 800px;

--- a/html/templates/resourcetype.html
+++ b/html/templates/resourcetype.html
@@ -114,7 +114,7 @@ $(document).ready(function() {
 	  </div>
 	  <div id="rightMainContent" class="ghCol">
 {% endif %}
-    <div id="resourceTypeInfo" class="ghWidgetBox" style="height:1600px;">
+    <div id="resourceTypeInfo" class="ghWidgetBox">
 {{ resHTML }}
 {% if typeID != '' %}
 	    <div id="busyImgSpawns" style="display:none;"><img src="/images/ghWait.gif" alt="waiting..." border=0 /></div>


### PR DESCRIPTION
## Changes
- Fix: Page horizontal overflow
- Fix: Align top-right column with page content
- Fix: Adjust top-center column to width 34% 
    + increases total header width from 99% to 100%
- Fix: Remove inline height declaration on `#resourceTypeInfo`

---

### Before

![css-bugs](https://user-images.githubusercontent.com/184307/27905612-751fba5c-620e-11e7-93d9-d2ab6dbb1c9a.png)

### After

![css-stylefix](https://user-images.githubusercontent.com/184307/27905620-7d291680-620e-11e7-8921-d26b154e3fc7.png)

---

Fixes #3, #5 
