### PR TITLE
Add 'milk' to creature resource listings

### DIFF
--- a/html/getCreatureResourceGroups.py
+++ b/html/getCreatureResourceGroups.py
@@ -50,7 +50,7 @@ if (cursor):
     FROM tResourceGroup
       INNER JOIN tResourceType ON tResourceType.resourceGroup = tResourceGroup.resourceGroup
       INNER JOIN tResourceTypeCreature ON tResourceTypeCreature.resourceType = tResourceType.resourceType
-    WHERE tResourceGroup.containerType IN ('bone', 'hide', 'meat')
+    WHERE tResourceGroup.containerType IN ('bone', 'hide', 'meat', 'milk')
       AND tResourceTypeCreature.galaxy IN (0, %s)
     GROUP BY tResourceGroup.resourceGroup
     ORDER BY tResourceGroup.resourceGroup

--- a/html/templates/creaturelist.html
+++ b/html/templates/creaturelist.html
@@ -95,7 +95,7 @@ function refreshResourceTypes() {
       <div id="resCreatures"></div>
     {% else %}
       <div class="selectContainer">
-      {% for type in ['bone', 'hide', 'meat'] %}
+      {% for type in ['bone', 'hide', 'meat', 'milk'] %}
         <div>
           <p>
             <a href="/creatureList.py/{{ type }}" class="bigLink">


### PR DESCRIPTION
## Changes

- We want to include all creature resources in listings
  + Previously we only included bone, hide, and meat
  + Milk has not been included in these listings
- Adds `milk` to creature resource group fetching
- Adds `milk` to creature harvesting index template

## Screenshots

<img width="905" alt="index" src="https://user-images.githubusercontent.com/184307/45581246-90306380-b868-11e8-9f6f-10d53c32a22e.png">
<img width="303" alt="sidebar" src="https://user-images.githubusercontent.com/184307/45581248-9292bd80-b868-11e8-9839-ba70ba593d17.png">

## Notes

It seems like the local database seed doesn't include all milk types (domesticated, etc) but it seems that these endpoints are fine in production.