### PR TITLE
Cleaner planet icons

### DIFF
--- a/html/ghObjects.py
+++ b/html/ghObjects.py
@@ -76,17 +76,16 @@ class resourceSpawn:
 		criteriaStr = ''
 
 		for planet in self.planets:
+			availability = planet.planetName + ' - not available'
 			result = result + '    <li class="planetBarBox'
 			if (planet.enteredBy != None):
 				result = result + ' ' + planet.planetName.replace(' ','')
 				result +='"'
-			if (planet.enteredBy != None):
-				result = result + ' title="'+planet.planetName+' marked available by '+planet.enteredBy+'"'
+				availability = 'marked available by '+ planet.enteredBy
 				result = result + ' onclick="planetRemove(this,'+str(planet.planetID)+','+str(self.spawnID)+',\''+planet.planetName+'\');"'
 			else:
-				result = result + ' title="'+planet.planetName+' - not available"'
-				result = result + ' onclick="planetAdd(this,'+str(planet.planetID)+','+str(self.spawnID)+',\''+planet.planetName+'\');"'
-			result = result + '>'+planet.planetName[0]+'</li>'
+				result = result + '" onclick="planetAdd(this,'+str(planet.planetID)+','+str(self.spawnID)+',\''+planet.planetName+'\');"'
+			result = result + ' title="'+ availability +'">'+planet.planetName[0]+'</li>'
 
 		result += '</ul>'
 		return result
@@ -320,7 +319,7 @@ class resourceSpawn:
 					result += '  <img src="/images/xRed16.png" alt="Unavailable" title="Unavailable" /><span style="vertical-align:4px;">' + ghShared.timeAgo(self.unavailable) + ' ago by <a href="' + ghShared.BASE_SCRIPT_URL + 'user.py/'+self.unavailableBy+'">'+self.unavailableBy+'</a></span>'
 				result += '  </div></div>'
 			else:
-				result += '    <div style="width: 248px;clear:both;margin-left:64px;">'+self.getPlanetBar()+'</div>'
+				result += '    <div style="width: 248px;clear:both;margin-left:64px; padding:2px 0px;">'+self.getPlanetBar()+'</div>'
 		else:
 			if (self.unavailable == None and currentUser != '' and reputation >= ghShared.MIN_REP_VALS['VERIFY_RESOURCE'] and ghShared.timeAgo(self.verified).find('minute') == -1):
 				result += '  <div id="cont_verify_'+self.spawnName+'" style="width:100px;float:right;"><input type="checkbox" id="chkVerify_' + self.spawnName + '" />Verify</div>'

--- a/html/style/ghCore.css
+++ b/html/style/ghCore.css
@@ -255,22 +255,7 @@ input.ghButton[disabled] {
 	border-radius: 2px;
 	min-height: 80px;
 }
-.planetBarBox {
-	background-repeat: no-repeat;
-	color: #b3b3b3;
-	width: 16px;
-	min-height: 16px;
-	display: -moz-inline-stack;
-	display: inline-block;
-	zoom: 1;
-	*display: inline;
-	_height: 16px;
-	margin: -2px;
-	text-align: center;
-	vertical-align: middle;
-	line-height: 16px;
-	cursor: pointer;
-}
+
 .feedList li {
 	background-image: url(http://www.feedburner.com/fb/images/pub/feed-icon16x16.png);
 	background-repeat: no-repeat;
@@ -280,126 +265,116 @@ input.ghButton[disabled] {
 .feedList li div {
 	margin-left: 8px;
 }
+/* Planet Icons */
+
+.planetBarBox {
+	border: 0.5px #b3b3b3 solid;
+	border-radius: 50%;
+	color: #b3b3b3;
+	background-color: #353535;
+	width: 16px;
+	min-height: 16px;
+	display: inline-block;
+	zoom: 1;
+	margin: -2px;
+	text-align: center;
+	vertical-align: middle;
+	line-height: 16px;
+	cursor: pointer;
+	margin-right: 2px;
+	font-size: 8px;
+}
 .Chandrila {
-	/*background-color: #32cd99;*/
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -82px;
+	background-color: #32cd99;
 }
 .Corellia {
-	/*background-color: #26466d;*/
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -46px;
+	background-color: #26466d;
 }
 .Dantooine {
-	/*background-color: #9a32cd;*/
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -118px;
+	background-color: #703a69;
 }
 .Dathomir {
-	/*background-color: #ff6103;*/
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -10px;
+	background-color: #70473a;
 }
 .Endor {
-	/*background-color: #3b5323;*/
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -154px;
+	background-color: #3b5323;
 }
 .Ghomrassen {
-	/*background-color: #ffcc11;*/
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -262px;
+	background-color: #c9b262;
+	color: #3f3f3f !important;
 }
 .NalHutta {
-	/*background-color: #ffcc11;*/
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -262px;
+	background-color: #c9b262;
+	color: #3f3f3f !important;
 }
 .Lok {
-	/*background-color: #666600;*/
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -190px;
+	background-color: #70683b;
 }
 .Naboo {
-	/*background-color: #333300;*/
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -226px;
+	background-color: #446b7a;
 }
 .Rori {
-	/*background-color: #dc143c;*/
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -334px;
+	background-color: #8d4856;
 }
 .Talus {
-	/*background-color: #32cd99;*/
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -82px;
+	background-color: #539b83;
+	color: #3f3f3f !important;
 }
 .Tatooine {
-	/*background-color: #ffcc11;*/
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -262px;
+	background-color: #c9b262;
+	color: #3f3f3f !important;
 }
 .Yavin4 {
-	/*background-color: #7cfc00;*/
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -298px;
+	background-color: #489c56;
+	color: #3f3f3f !important;
 }
 .Hoth {
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -370px;
+	background-color: #c0c9ca;
+	color: #3f3f3f !important;
 }
 .DromundKaas {
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -406px;
+	background-color: #4c385a;
 }
 .Kashyyyk {
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -442px;
+	background-color: #5a6d48;
 }
 .Mandalore {
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -478px;
+	background-color: #666d48;
 }
 .Mustafar {
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -514px;
+	background-color: #8d452f;
 }
 .Taanab {
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -550px;
+	background-color: #486d56;
 }
 .Lothal {
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -586px;
+	background-color: #70683b;
 }
 .Jakku {
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -262px;
+	background-color: #a1895c;
 }
 .OrdMantell {
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -190px;
+	background-color: #726e4e;
 }
 .Kuat {
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -154px;
+	background-color: #85b448;
+	color: #3f3f3f !important;
 }
 .Moraband {
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -10px;
+	background-color: #b8642c;
+	color: #3f3f3f !important;
 }
 .Coruscant {
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -478px;
+	background-color: #ac7550;
+	color: #3f3f3f !important;
 }
 .Florrum {
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -190px;
+	background-color: #c9b262;
+	color: #3f3f3f !important;
 }
 .Sullust {
-	background-image: url(/images/spriteCircles16.png);
-	background-position: -10px -478px;
+	background-color: #c99c62;
+	color: #3f3f3f !important;
 }
 .resourceStats td {
 	text-align: center;


### PR DESCRIPTION
Hacky CSS methods/sprite sheets are no longer needed to render circles. 

- Added padding to the planetbar to make it look less janky
- Re-coloured all available planets to be softer, contrasting text for lighter planets
- Fixed issue that made the title not display on planets that had not been added (there was a missing ")
- Tweaked the conditional for availability so that there's no need to repeat it

![chrome_PQJWkOxktq](https://user-images.githubusercontent.com/7548280/130145811-d7917fda-e970-4a3c-a6da-f86435cc51e4.png)
![chrome_BIXIcgpbjS](https://user-images.githubusercontent.com/7548280/130145874-ed8002a3-034a-46b1-b91e-da7c62c6017a.png)
