### PR TITLE
Dockerize app for development

### DIFF
--- a/.docker/apache2.conf
+++ b/.docker/apache2.conf
@@ -1,0 +1,154 @@
+# Global configuration
+#
+
+#
+# The directory where shm and other runtime files will be stored.
+#
+
+DefaultRuntimeDir ${APACHE_RUN_DIR}
+
+#
+# PidFile: The file in which the server should record its process
+# identification number when it starts.
+# This needs to be set in /etc/apache2/envvars
+#
+PidFile ${APACHE_PID_FILE}
+
+#
+# Timeout: The number of seconds before receives and sends time out.
+#
+Timeout 300
+
+#
+# KeepAlive: Whether or not to allow persistent connections (more than
+# one request per connection). Set to "Off" to deactivate.
+#
+KeepAlive On
+
+#
+# MaxKeepAliveRequests: The maximum number of requests to allow
+# during a persistent connection. Set to 0 to allow an unlimited amount.
+# We recommend you leave this number high, for maximum performance.
+#
+MaxKeepAliveRequests 100
+
+#
+# KeepAliveTimeout: Number of seconds to wait for the next request from the
+# same client on the same connection.
+#
+KeepAliveTimeout 5
+
+
+# These need to be set in /etc/apache2/envvars
+User ${APACHE_RUN_USER}
+Group ${APACHE_RUN_GROUP}
+
+#
+# HostnameLookups: Log the names of clients or just their IP addresses
+# e.g., www.apache.org (on) or 204.62.129.132 (off).
+# The default is off because it'd be overall better for the net if people
+# had to knowingly turn this feature on, since enabling it means that
+# each client request will result in AT LEAST one lookup request to the
+# nameserver.
+#
+HostnameLookups Off
+
+# ErrorLog: The location of the error log file.
+# If you do not specify an ErrorLog directive within a <VirtualHost>
+# container, error messages relating to that virtual host will be
+# logged here.  If you *do* define an error logfile for a <VirtualHost>
+# container, that host's errors will be logged there and not here.
+#
+ErrorLog ${APACHE_LOG_DIR}/error.log
+
+#
+# LogLevel: Control the severity of messages logged to the error_log.
+# Available values: trace8, ..., trace1, debug, info, notice, warn,
+# error, crit, alert, emerg.
+# It is also possible to configure the log level for particular modules, e.g.
+# "LogLevel info ssl:warn"
+#
+LogLevel warn
+
+# Include module configuration:
+IncludeOptional mods-enabled/*.load
+IncludeOptional mods-enabled/*.conf
+
+# Include list of ports to listen on
+Include ports.conf
+
+
+# Sets the default security model of the Apache2 HTTPD server. It does
+# not allow access to the root filesystem outside of /usr/share and /var/www.
+# The former is used by web applications packaged in Debian,
+# the latter may be used for local directories served by the web server. If
+# your system is serving content from a sub-directory in /srv you must allow
+# access here, or in any related virtual host.
+<Directory />
+  Options FollowSymLinks
+  AllowOverride None
+  Require all denied
+</Directory>
+
+<Directory /usr/share>
+  AllowOverride None
+  Require all granted
+</Directory>
+
+<Directory /var/www/>
+  Options Indexes FollowSymLinks
+  AllowOverride None
+  Require all granted
+</Directory>
+
+ServerName localhost
+<Directory /var/www/html>
+  AddHandler cgi-script .py
+  DirectoryIndex index.html
+  Options +ExecCGI
+</Directory>
+
+
+# AccessFileName: The name of the file to look for in each directory
+# for additional configuration directives.  See also the AllowOverride
+# directive.
+#
+AccessFileName .htaccess
+
+#
+# The following lines prevent .htaccess and .htpasswd files from being
+# viewed by Web clients.
+#
+<FilesMatch "^\.ht">
+  Require all denied
+</FilesMatch>
+
+
+#
+# The following directives define some format nicknames for use with
+# a CustomLog directive.
+#
+# These deviate from the Common Log Format definitions in that they use %O
+# (the actual bytes sent including headers) instead of %b (the size of the
+# requested file), because the latter makes it impossible to detect partial
+# requests.
+#
+# Note that the use of %{X-Forwarded-For}i instead of %h is not recommended.
+# Use mod_remoteip instead.
+#
+LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%h %l %u %t \"%r\" %>s %O" common
+LogFormat "%{Referer}i -> %U" referer
+LogFormat "%{User-agent}i" agent
+
+# Include of directories ignores editors' and dpkg's backup files,
+# see README.Debian for details.
+
+# Include generic snippets of statements
+IncludeOptional conf-enabled/*.conf
+
+# Include the virtual host configurations:
+IncludeOptional sites-enabled/*.conf
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/.docker/docker-entrypoint-initdb.d/00-create-webusr-users.sql
+++ b/.docker/docker-entrypoint-initdb.d/00-create-webusr-users.sql
@@ -1,0 +1,2 @@
+CREATE USER 'webusr'@'%' IDENTIFIED BY '';
+CREATE USER 'webusr'@'localhost' IDENTIFIED BY '';

--- a/.docker/docker-entrypoint-initdb.d/02-grant-webusr-global.sql
+++ b/.docker/docker-entrypoint-initdb.d/02-grant-webusr-global.sql
@@ -1,0 +1,1 @@
+GRANT SELECT,INSERT,UPDATE,DELETE ON swgresource.* TO 'webusr'@'%';

--- a/.docker/run.sh
+++ b/.docker/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+force_stop_apache2ctl () {
+  apache2ctl -k stop
+}
+
+trap "force_stop_apache2ctl" EXIT
+
+apache2ctl -DFOREGROUND

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:22.04
+
+# install server and app dependencies
+RUN apt update
+RUN apt install -y apache2 apache2-utils
+RUN apt install -y python3 python3-pip
+RUN apt clean
+
+# enable CGI mods for apache2 server
+RUN a2enmod cgi
+RUN a2enmod cgid
+COPY .docker/apache2.conf /etc/apache2/apache2.conf
+RUN service apache2 restart
+
+# set working directory to apache2 default location
+WORKDIR /var/www
+
+# install required python3 libraries
+COPY requirements.txt ./requirements.txt
+RUN python3 -m pip install -r ./requirements.txt
+
+# copy app files
+COPY database ./database
+COPY html ./html
+COPY scripts ./scripts
+COPY *.py ./
+
+# allow temp folder to be written to (blog, etc.)
+RUN chmod 777 /var/www/html/temp
+
+# use container name as mysql host
+RUN sed -i 's/localhost/galaxyharvester-db/g' ./dbInfo.py
+
+# update base URL for blog to use port 8888
+RUN sed -i 's/localhost\/blog.py/localhost:8888\/blog.py/g' ./kukkaisvoima_settings.py
+
+EXPOSE 80
+COPY .docker/run.sh ./run.sh
+CMD [ "/var/www/run.sh" ]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ The following software must be set up on the server prior to setting up Galaxy H
  * module: Pillow (8.0)
 
 ### Web Server Configuration:
+
+> **Want to use Docker?**
+> See: [Docker instructions (experimental)](#docker).
+
 The web server being used must be configured to serve the Python based CGI scripts as follows
 
 * Set "html" folder of this repo as web site root (for apache2 update DocumentRoot in /etc/apache2/sites-enabled/000-default.conf)
@@ -63,3 +67,13 @@ Galaxy Harvester seed data includes creature and schematic data that is automati
 
 ### Presentation Templates
 In most cases, Galaxy Harvester uses the [Jinja2](http://jinja.pocoo.org/) template engine to render any html to the user.  The html folder contains various scripts, some of which are called by AJAX from an already rendered page, and some of which render one of the templates under html/templates.  The blocks.html template is not rendered directly but has various blocks like headers and footers that are imported by the other templates.
+
+### Docker
+
+> **This is currently experimental.**
+
+To run a development environment using Docker, including the app server and MySQL server, you can run:
+
+```bash
+docker-compose up --build
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3"
+name: galaxyharvester
+services:
+  app:
+    container_name: galaxyharvester-app
+    ports:
+      - "8888:80"
+    build:
+      dockerfile: ./Dockerfile
+    links:
+      - "db"
+  db:
+    container_name: galaxyharvester-db
+    image: mysql:5.7.11
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: 'password'
+    ports:
+      - '3305:3306'
+    expose:
+      - '3306'
+    volumes:
+      - ./.docker/docker-entrypoint-initdb.d/00-create-webusr-users.sql:/docker-entrypoint-initdb.d/00-create-webusr-users.sql
+      - ./database/createSWGresourcedb.sql:/docker-entrypoint-initdb.d/01-create-database.sql
+      - ./.docker/docker-entrypoint-initdb.d/02-grant-webusr-global.sql:/docker-entrypoint-initdb.d/02-grant-webusr-global.sql
+      - ./database/seedData:/var/www/database/seedData
+      - db:/var/lib/mysql
+volumes:
+  db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       dockerfile: ./Dockerfile
     links:
       - "db"
+    develop:
+      watch:
+        - action: sync
+          path: ./html
+          target: /var/www/html
   db:
     container_name: galaxyharvester-db
     image: mysql:5.7.11


### PR DESCRIPTION
## Context

Run application via `docker-compose`, with all dependencies -- including mysql -- managed via docker.

You can try it with:

```bash
docker-compose up --build
```

Or, if you want to see changes in the `./html` folder synchronized with the container, you can _watch_ it using:

```bash
docker compose watch
```

## Background

I rarely use MySQL. I use Python less than that. I use apache2 least of the bunch. Any time I've gotten a new dev machine, I've found it takes me hours (spread across multiple days sometimes) to get all the gotchas ironed out. Nothing egregious, but some of these decencies are fairly old and more difficult to find support for.

So I decided to dockerize it while its all fresh in my mind.

## Features

- application managed via Dockerfile
- MySQL uses official 5.7 image via `docker-compose`
- database _automatically_ creates `webusr` and seeds data on initialize (i.e. only on first run)

## Caveats

- Docker isn't a regular tool that I use -- very open to feedback and suggestions
- I did not test _every_ feature -- I clicked around and things looked fine

Otherwise, I tried to make the changes as lightweight as possible. This is why you'll see the use of `sed` to replace content in configuration files, or creating `'webusr'@'%'` _and_ `'webusr'@'localhost'` -- I wanted to limit having to duplicate configurations for docker and non-docker.