### PR TITLE
bugfix: populate resource type list immediately

### DIFF
--- a/html/templates/alerts.html
+++ b/html/templates/alerts.html
@@ -65,13 +65,13 @@ function addFilterRow(tableName, numset) {
     if (numset == null) {
         numset = rownum;
     }
-    if (true) {
-      var typeGroupBox = "typeGroupSel" + numset;
-      var qualityRow = "";
-      if ( tableName.includes("Quality") ) {
+
+    var typeGroupBox = "typeGroupSel" + numset;
+    var qualityRow = "";
+    if ( tableName.includes("Quality") ) {
         qualityRow = "<td align='center'><input type='text' size=4 maxlength=4 id='minQuality"+numset+"' name='minQuality"+numset+"'></td>";
-      }
-      $("#"+tableName).append("<tr height=16px valign=middle id='resRow"+numset+"' class='filterRow'><td><input type='radio' name='oResTG"+numset+"' id='oType"+numset+"' value='ByType' checked='checked' onclick='setTGlist("+numset+")' />Type<input type='radio' name='oResTG"+numset+"' id='oGroup"+numset+"' value='ByGroup' onclick='setTGlist("+numset+")' />Group</td>"+
+    }
+    $("#"+tableName).append("<tr height=16px valign=middle id='resRow"+numset+"' class='filterRow'><td><input type='radio' name='oResTG"+numset+"' id='oType"+numset+"' value='ByType' checked='checked' onclick='setTGlist("+numset+")' />Type<input type='radio' name='oResTG"+numset+"' id='oGroup"+numset+"' value='ByGroup' onclick='setTGlist("+numset+")' />Group</td>"+
         "<td><select name='"+typeGroupBox+"' id='"+typeGroupBox+"' style='width:200px;' onchange='maskStats(this);'></select></td>"+
         "<td><input type='text' size=2 maxlength=4 id='ER"+numset+"' name='ER"+numset+"'></td>"+
         "<td><input type='text' size=2 maxlength=4 id='CR"+numset+"' name='CR"+numset+"'></td>"+
@@ -91,8 +91,7 @@ function addFilterRow(tableName, numset) {
         "<td><img src='/images/xRed16.png' alt='red x' title='Remove this row' style='cursor:pointer' onclick='removeRow("+numset+")'/></td>"+
         "<td style='padding-left:6px;'><input id='fltGroup"+numset+"' type='text' size=14 maxlength=255></input></td>"+
         "</tr>");
-      rownum = numset + 1;
-    }
+    rownum = numset + 1;
 
     return numset;
 }

--- a/html/templates/alerts.html
+++ b/html/templates/alerts.html
@@ -93,6 +93,8 @@ function addFilterRow(tableName, numset) {
         "</tr>");
       rownum = numset + 1;
     }
+
+    return numset;
 }
 
 function maskStats(typeSel) {
@@ -215,13 +217,13 @@ function maskStats(typeSel) {
       <tr class="tableHead"><td colspan=2 style="text-align:center;">Resource Types</td><td colspan=11 style="font-weight:bold;text-align:center;">Stat % Weights</td><td>Min Quality</td><td colspan=3 style="font-weight:bold;text-align:center;">Alert Types</td></tr>
       <tr><td>Res. Option</td><td>Resource</td><td>ER</td><td>CR</td><td>CD</td><td>DR</td><td>FL</td><td>HR</td><td>MA</td><td>PE</td><td>OQ</td><td>SR</td><td>UT</td><td align="center">Value</td><td width="40" align="center">Site</td><td width="40" align="center">E-Mail</td><td width="40" align="center">Mobile</td><td></td><td style='padding-lef:8px;'>Group/Note</td></tr>
       </thead></table>
-      <img src="/images/plusGreen32.png" alt="plus sign" title="Add another quality filter definition row" onclick="addFilterRow('addQualityAlertTable');setTGlist();" style="cursor:pointer;margin-right:120px;"/>
+      <img src="/images/plusGreen32.png" alt="plus sign" title="Add another quality filter definition row" onclick="setTGlist(addFilterRow('addQualityAlertTable'));" style="cursor:pointer;margin-right:120px;"/>
       <h3>Raw Stat Value Triggered</h3>
       <table id="addAlertTable"><thead>
       <tr class="tableHead"><td colspan=2 style="text-align:center;">Resource Types</td><td colspan=11 style="font-weight:bold;text-align:center;">Minimum Stat Values</td><td colspan=3 style="font-weight:bold;text-align:center;">Alert Types</td></tr>
       <tr><td>Res. Option</td><td>Resource</td><td>ER</td><td>CR</td><td>CD</td><td>DR</td><td>FL</td><td>HR</td><td>MA</td><td>PE</td><td>OQ</td><td>SR</td><td>UT</td><td width="40" align="center">Site</td><td width="40" align="center">E-Mail</td><td width="40" align="center">Mobile</td><td></td><td style='padding-lef:8px;'>Group/Note</td></tr>
       </thead></table>
-      <img src="/images/plusGreen32.png" alt="plus sign" title="Add another filter definition row" onclick="addFilterRow('addAlertTable');setTGlist();" style="cursor:pointer;margin-right:120px;"/>
+      <img src="/images/plusGreen32.png" alt="plus sign" title="Add another filter definition row" onclick="setTGlist(addFilterRow('addAlertTable'));" style="cursor:pointer;margin-right:120px;"/>
       <div id="sendResponse" style="display:none;"></div>
       </form>
     </div>


### PR DESCRIPTION
## Changes

Set `addFilterRow` to return the value of `numset`, and then pass the return value into `setTGlist`. An alternative approach might be to allow for an optional third parameter to `addFilterRow` that would conditionally call `setTGlist`. I decided against this because the second argument is already optional.

I also removed a redundant condition, i.e. `if (true) { ... }`

## Before

![before](https://github.com/pwillworth/galaxyharvester/assets/184307/b2bc06b7-fb4a-4105-aa34-6d806289f2f6)

## After

![after](https://github.com/pwillworth/galaxyharvester/assets/184307/dc6f87cb-c720-4c18-8d59-c6db89c5292c)

---

Fixes #65 