### PR TITLE
bugfix: scope ingredient components to selected galaxy

### DIFF
--- a/html/getComponentList.py
+++ b/html/getComponentList.py
@@ -29,6 +29,7 @@ form = cgi.FieldStorage()
 
 craftingTab = form.getfirst('craftingTab', '')
 outType = form.getfirst('outType', '')
+galaxy = form.getfirst('galaxy', '')
 # escape input to prevent sql injection
 craftingTab = dbShared.dbInsertSafe(craftingTab)
 outType = dbShared.dbInsertSafe(outType)
@@ -41,6 +42,18 @@ else:
 	criteriaStr = ''
 
 conn = dbShared.ghConn()
+
+if galaxy.isdigit():
+	baseProfs = '0, 1337'
+	checkCursor = conn.cursor()
+	if (checkCursor):
+		checkCursor.execute('SELECT galaxyNGE FROM tGalaxy WHERE galaxyID={0};'.format(str(galaxy)))
+		checkRow = checkCursor.fetchone()
+		if (checkRow != None) and (checkRow[0] > 0):
+			baseProfs = '-1, 1337'
+		checkCursor.close()
+	criteriaStr = criteriaStr + ' AND tSchematic.galaxy IN ({1}, {0}) AND tSchematic.schematicID NOT IN (SELECT schematicID FROM tSchematicOverrides WHERE galaxyID={0})'.format(galaxy, baseProfs)
+
 cursor = conn.cursor()
 if (cursor):
 	queryStr = f"""


### PR DESCRIPTION
## Changes

- reads `galaxy` from form params
- conditionally filters for schematics where:
    + the galaxy matches `galaxy` from params OR is in the default groups (`0, 1337` / `-1, 1337`)
    + the schematicID is not found in `tSchematicOverrides` table

There's a check for `if galaxy.isdigit()`, but I think it should _always_ be a digit. If so, maybe we should raise an exception if galaxy isn't a number? Maybe that's overkill.

---

Fixes #67 