### PR TITLE
touch cache files for `checkAlerts.py` (Docker)

### DIFF
--- a/.docker/run.sh
+++ b/.docker/run.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
 
-# touch last alert check files if they don't exist.
-# (Note: /var/www/cache may be a volume created via `docker-compose``)
-touch /var/www/cache/last_alerts_check_added.txt
-touch /var/www/cache/last_alerts_check_removed.txt
-chmod 777 /var/www/cache/last_alerts_check_*.txt
-
 # symlink the cache for last alert check files to be available in www root
-# (Note: used by `checkAlerts/py`)
+# (Note: used by `checkAlerts.py`)
 ln -s /var/www/cache/last_alerts_check_added.txt /var/www/last_alerts_check_added.txt
 ln -s /var/www/cache/last_alerts_check_removed.txt /var/www/last_alerts_check_removed.txt
 

--- a/.docker/run.sh
+++ b/.docker/run.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 
+# touch last alert check files if they don't exist.
+# (Note: /var/www/cache may be a volume created via `docker-compose``)
+touch /var/www/cache/last_alerts_check_added.txt
+touch /var/www/cache/last_alerts_check_removed.txt
+chmod 777 /var/www/cache/last_alerts_check_*.txt
+
+# symlink the cache for last alert check files to be available in www root
+# (Note: used by `checkAlerts/py`)
+ln -s /var/www/cache/last_alerts_check_added.txt /var/www/last_alerts_check_added.txt
+ln -s /var/www/cache/last_alerts_check_removed.txt /var/www/last_alerts_check_removed.txt
+
+# trap exits and kill them properly
 force_stop_apache2ctl () {
   apache2ctl -k stop
 }
-
 trap "force_stop_apache2ctl" EXIT
 
+# start server
 apache2ctl -DFOREGROUND

--- a/README.md
+++ b/README.md
@@ -77,3 +77,13 @@ To run a development environment using Docker, including the app server and MySQ
 ```bash
 docker-compose up --build
 ```
+
+#### Hot Reloading
+
+If you want to automatically update and preview your running services as you edit and save your code, you can start the services using:
+
+```bash
+docker-compose watch
+```
+
+> Note: after exiting from `watch`, you may need to run `docker compose stop` to stop the services.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
         - action: sync
           path: ./html
           target: /var/www/html
+    volumes:
+      - cache:/var/www/cache
+
   db:
     container_name: galaxyharvester-db
     image: mysql:5.7.11
@@ -31,4 +34,5 @@ services:
       - ./database/seedData:/var/www/database/seedData
       - db:/var/lib/mysql
 volumes:
+  cache:
   db:


### PR DESCRIPTION
These changes ensure the following files - if not already persisted in the volume - are touched:

- `last_alerts_check_added.txt`
- `last_alerts_check_removed.txt`

Without these files, `checkAlerts.py` will always skip certain checks. We persist changes to these files via volume in the docker compose configuration.