### PR TITLE
[DO NOT MERGE] conditionally filter schematic components to galaxy

### DIFF
--- a/html/dbShared.py
+++ b/html/dbShared.py
@@ -536,6 +536,17 @@ def alertNewAbility(conn, userID, abilityKey, galaxy):
 	alertcursor.close()
 
 def getBaseProfs(galaxy):
+	# Short-circuit returns on system galaxy IDs (NGE, Non-NGE, Jedi). Move on if neither.
+	match str(galaxy):
+		case '-1':
+			return '-1, 1337'
+		case '0':
+			return '0, 1337'
+		case '1337':
+			return '-1, 0, 1337'
+		case _:
+			pass
+
 	# Determine set of base profession galaxy IDs to include by checking if galaxy is flagged NGE
 	baseProfs = '0, 1337'
 	conn = ghConn()

--- a/html/schematics.py
+++ b/html/schematics.py
@@ -374,6 +374,7 @@ def main():
 		schematic=s,
 		schematicID=schematicID,
 		schematicTabList=ghLists.getSchematicTabList(),
+		selectedGalaxy=galaxy,
 		siteidCAPTCHA=ghShared.RECAPTCHA_SITEID,
 		statList=ghLists.getStatList(),
 		uiTheme=uiTheme,

--- a/html/schematics.py
+++ b/html/schematics.py
@@ -132,6 +132,10 @@ def getProfession(conn, skillGroup):
 		return 0
 	profCursor.close()
 
+def displayGalaxyMismatchNotice(schematic, selectedGalaxy):
+	return (schematic and schematic.galaxy not in (-1, 0, 1337) and
+					str(selectedGalaxy) != str(schematic.galaxy))
+
 def main():
 	# Get current url
 	try:
@@ -373,6 +377,7 @@ def main():
 		canAdd=canAdd,
 		canEdit=canEdit,
 		currentUser=currentUser,
+		displayGalaxyMismatchNotice=displayGalaxyMismatchNotice(s, galaxy),
 		enableCAPTCHA=ghShared.RECAPTCHA_ENABLED,
 		favHTML=favHTML,
 		galaxyList=ghLists.getGalaxyList(),

--- a/html/schematics.py
+++ b/html/schematics.py
@@ -353,7 +353,32 @@ def main():
 		template = env.get_template('schematiceditor.html')
 	else:
 		template = env.get_template('schematics.html')
-	print(template.render(uiTheme=uiTheme, loggedin=logged_state, currentUser=currentUser, loginResult=loginResult, linkappend=linkappend, url=url, pictureName=pictureName, imgNum=ghShared.imgNum, galaxyList=ghLists.getGalaxyList(), professionList=ghLists.getProfessionList(galaxy), schematicTabList=ghLists.getSchematicTabList(), objectTypeList=ghLists.getObjectTypeList(), noenergyTypeList=ghLists.getOptionList('SELECT resourceType, resourceTypeName FROM tResourceType WHERE resourceCategory != "energy" ORDER BY resourceTypeName;'), resourceGroupList=ghLists.getResourceGroupList(), resourceGroupListShort=groupListShort, statList=ghLists.getStatList(), schematicID=schematicID, schematic=s, favHTML=favHTML, canEdit=canEdit, profession=profession, canAdd=canAdd, enableCAPTCHA=ghShared.RECAPTCHA_ENABLED, siteidCAPTCHA=ghShared.RECAPTCHA_SITEID))
+	print(template.render(
+		canAdd=canAdd,
+		canEdit=canEdit,
+		currentUser=currentUser,
+		enableCAPTCHA=ghShared.RECAPTCHA_ENABLED,
+		favHTML=favHTML,
+		galaxyList=ghLists.getGalaxyList(),
+		imgNum=ghShared.imgNum,
+		linkappend=linkappend,
+		loggedin=logged_state,
+		loginResult=loginResult,
+		noenergyTypeList=ghLists.getOptionList('SELECT resourceType, resourceTypeName FROM tResourceType WHERE resourceCategory != "energy" ORDER BY resourceTypeName;'),
+		objectTypeList=ghLists.getObjectTypeList(),
+		pictureName=pictureName,
+		profession=profession,
+		professionList=ghLists.getProfessionList(galaxy),
+		resourceGroupList=ghLists.getResourceGroupList(),
+		resourceGroupListShort=groupListShort,
+		schematic=s,
+		schematicID=schematicID,
+		schematicTabList=ghLists.getSchematicTabList(),
+		siteidCAPTCHA=ghShared.RECAPTCHA_SITEID,
+		statList=ghLists.getStatList(),
+		uiTheme=uiTheme,
+		url=url
+	))
 
 
 if __name__ == "__main__":

--- a/html/templates/schematics.html
+++ b/html/templates/schematics.html
@@ -305,6 +305,11 @@ function deleteSchematic() {
 {% endif %}
 
 {% if (schematicID != '' and schematicID != 'index' and schematicID != 'home') %}
+    {% if schematic.schematicID and schematic.galaxy != 0 and schematic.galaxy|string != selectedGalaxy %}
+    <div class="standOut" style="padding: 10px !important">
+        You're viewing a schematic for a different galaxy. Some ingredients may not exist your selected galaxy.
+    </div>
+    {% endif %}
     <h2>{{ schematic.schematicName }}
     {% if loggedin == 1 %}
         {{ favHTML }}

--- a/html/templates/schematics.html
+++ b/html/templates/schematics.html
@@ -305,7 +305,7 @@ function deleteSchematic() {
 {% endif %}
 
 {% if (schematicID != '' and schematicID != 'index' and schematicID != 'home') %}
-    {% if schematic.schematicID and schematic.galaxy != 0 and schematic.galaxy|string != selectedGalaxy %}
+    {% if displayGalaxyMismatchNotice %}
     <div class="standOut" style="padding: 10px !important">
         You're viewing a schematic for a different galaxy. Some ingredients may not exist your selected galaxy.
     </div>


### PR DESCRIPTION
⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️  

⚠️ ⚠️ ⚠️   **This PR is still under construction**  ⚠️ ⚠️ ⚠️ 

⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ 

---

## To Be Done

- [x] Update filter logic to account for NGE galaxies (i.e. `galaxyID=-1`)
- [x] Update schematic galaxy mismatch to account for NGE galaxies

---

## Summary

- if a galaxy is selected, and the schematic's is a base schematic, filter components for relevant base galaxies _and_ the **selected galaxy**
    + base galaxy ID `0` is non-NGE, relevant IDs: `0, 1337`
    + base galaxy ID `-1` is NGE, relevant IDs: `-1, 1337`
    + base galaxy ID `1337` is Jedi (shared), relevant IDs: `-1, 1337`
- if a galaxy is selected, and the schematic's is not a base schematic, filter components for relevant base galaxies _and_ the **schematic's galaxy**
    + base galaxy is determined using the schematic's galaxy as the seed for `dbShared.getBaseProfs/1`
    + `dbShared.getBaseProfs/1` was refactored to short-circuit returns when value is `-1`, `0`, or `1337`
- (_if a galaxy is not selected, no change_)
- add a notice when viewing a schematic for a different galaxy (unless base schematic, i.e. `galaxy in (-1, 0, 1337)`)

## Screen Shots

### Base schematic with custom components on different servers

In this case, we have two different servers ("Other" and "Test Server"). "Other" has a custom component `Super Custom Rifle Barrel`. "Test Server" has a custom component `Very Advanced Blaster Rifle Barrel`. Previously, both custom components would always show. Now, they only show when their respective galaxies are selected.

<img width="970" alt="Screenshot 2024-04-13 at 3 34 35 AM" src="https://github.com/pwillworth/galaxyharvester/assets/184307/64e13262-124d-4e8c-9011-a21e13afaf18">

<img width="965" alt="Screenshot 2024-04-13 at 3 34 48 AM" src="https://github.com/pwillworth/galaxyharvester/assets/184307/13898f38-119d-4a41-a3ac-520f70157783">

### Viewing a custom schematic from a different server

When viewing a custom schematic for a different server than selected, we display a notice above the schematic details, informing the user that not all ingredients may be available on their server. In this case, we always filter components to the schematic's galaxy (as well as where `galaxy=0`).

<img width="966" alt="Screenshot 2024-04-13 at 3 36 07 AM" src="https://github.com/pwillworth/galaxyharvester/assets/184307/75dd5361-1ec2-41b1-a52b-7bd2569a7967">

<img width="964" alt="Screenshot 2024-04-13 at 4 03 17 AM" src="https://github.com/pwillworth/galaxyharvester/assets/184307/78ea5276-a030-4ecc-b2c0-db3e7ec1b689">
