### PR TITLE
[QoL] docker compose watches for entire project changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     develop:
       watch:
         - action: sync
-          path: ./html
-          target: /var/www/html
+          path: ./
+          target: /var/www
   db:
     container_name: galaxyharvester-db
     image: mysql:5.7.11


### PR DESCRIPTION
## CONTEXT

This is a small PR completely geared towards development quality of life. For whatever reason, when I added the docker-compose file, I configured the `--watch` flag to only look for changes in the `/html` folder instead of the root of the project.

This PR changes the behavior to check for file changes anywhere in the project. This allows for automatic code reloading any time during development when running the project with `docker compose watch`