### PR TITLE
Add custom mandalorian resource types

### DIFF
--- a/database/updateIncremental/dbUpdate20250226.sql
+++ b/database/updateIncremental/dbUpdate20250226.sql
@@ -1,0 +1,39 @@
+use swgresource;
+
+ALTER TABLE tResourceType ADD COLUMN elective TINYINT DEFAULT 0;
+
+CREATE TABLE `tGalaxyResourceType` (
+  `galaxyID` int(11) NOT NULL,
+  `resourceType` varchar(63) NOT NULL,
+  PRIMARY KEY (`galaxyID`,`resourceType`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+INSERT INTO
+  `tResourceType`
+    (`resourceTypeName`, `resourceCategory`, `resourceGroup`, `maxTypes`, `enterable`, `resourceType`, `CRmin`, `CRmax`, `CDmin`, `CDmax`, `DRmin`, `DRmax`, `FLmin`, `FLmax`, `HRmin`, `HRmax`, `MAmin`, `MAmax`, `PEmin`, `PEmax`, `OQmin`, `OQmax`, `SRmin`, `SRmax`, `UTmin`, `UTmax`, `ERmin`, `ERmax`, `specificPlanet`, `inventoryType`, `containerType`, `elective`)
+  VALUES
+    ('Mandalorian Type 1 Crystal Amorphous Gem', 'mineral', 'gemstone_armophous', 2, 1, 'amorphous_mandalore_1', 600, 1000, 0, 0, 600, 1000, 0, 0, 600, 1000, 300, 700, 0, 0, 1, 1000, 600, 1000, 600, 1000, 1, 900, 0, 'gemstone', 'gemstone', 1),
+    ('Mandalorian Type 2 Crystal Amorphous Gem', 'mineral', 'gemstone_armophous', 2, 1, 'amorphous_mandalore_2', 600, 1000, 0, 0, 600, 1000, 0, 0, 600, 1000, 300, 700, 0, 0, 1, 1000, 600, 1000, 600, 1000, 1, 900, 0, 'gemstone', 'gemstone', 1),
+    ('Mandalorian Type 1 Crystalline Gem', 'mineral', 'gemstone_crystalline', 2, 1, 'crystalline_mandalore_1', 600, 1000, 0, 0, 500, 1000, 0, 0, 600, 1000, 1, 500, 0, 0, 300, 1000, 600, 1000, 600, 1000, 700, 1000, 0, 'gemstone', 'gemstone', 1),
+    ('Mandalorian Type 2 Crystalline Gem', 'mineral', 'gemstone_crystalline', 2, 1, 'crystalline_mandalore_2', 600, 1000, 0, 0, 500, 1000, 0, 0, 600, 1000, 1, 500, 0, 0, 300, 1000, 600, 1000, 600, 1000, 700, 1000, 0, 'gemstone', 'gemstone', 1);
+
+INSERT INTO
+  `tResourceTypeGroup`
+    (`resourceType`, `resourceGroup`)
+  VALUES
+    ('amorphous_mandalore_1', 'inorganic'),
+    ('amorphous_mandalore_1', 'mineral'),
+    ('amorphous_mandalore_1', 'gemstone'),
+    ('amorphous_mandalore_1', 'gemstone_armophous'),
+    ('amorphous_mandalore_2', 'inorganic'),
+    ('amorphous_mandalore_2', 'mineral'),
+    ('amorphous_mandalore_2', 'gemstone'),
+    ('amorphous_mandalore_2', 'gemstone_armophous'),
+    ('crystalline_mandalore_1', 'inorganic'),
+    ('crystalline_mandalore_1', 'mineral'),
+    ('crystalline_mandalore_1', 'gemstone'),
+    ('crystalline_mandalore_1', 'gemstone_crystalline'),
+    ('crystalline_mandalore_2', 'inorganic'),
+    ('crystalline_mandalore_2', 'mineral'),
+    ('crystalline_mandalore_2', 'gemstone'),
+    ('crystalline_mandalore_2', 'gemstone_crystalline');

--- a/html/galaxy.py
+++ b/html/galaxy.py
@@ -78,6 +78,7 @@ def getElectiveResourceTypeList(conn, galaxy, available):
 	cursor.close()
 	return listHTML
 
+
 def main():
 	useCookies = 1
 	linkappend = ''
@@ -161,8 +162,6 @@ def main():
 		galaxy = dbShared.dbInsertSafe(path[0])
 		conn = dbShared.ghConn()
 		galaxyAdminList = dbShared.getGalaxyAdminList(conn, currentUser)
-		availablePlanetList = getPlanetList(conn, galaxy, 1)
-		availableResourceTypeList = getElectiveResourceTypeList(conn, galaxy, 1)
 		if galaxy.isdigit():
 			# get the galaxy details for edit
 			galaxyCursor = conn.cursor()
@@ -176,6 +175,8 @@ def main():
 				galaxyWebsite = galaxyRow[3]
 			galaxyCursor.close()
 			galaxyPlanetList = getPlanetList(conn, galaxy, 0)
+			availablePlanetList = getPlanetList(conn, galaxy, 1)
+			availableResourceTypeList = getElectiveResourceTypeList(conn, galaxy, 1)
 			galaxyResourceTypeList = getElectiveResourceTypeList(conn, galaxy, 0)
 			galaxyAdmins = dbShared.getGalaxyAdmins(conn, galaxy)
 			conn.close()

--- a/html/galaxy.py
+++ b/html/galaxy.py
@@ -70,7 +70,7 @@ def getElectiveResourceTypeList(conn, galaxy, available):
 	""".format(is_or_is_not_null)
 
 	cursor = conn.cursor()
-	cursor.execute(resourceTypeSQL, {'galaxy': galaxy})
+	cursor.execute(resourceTypeSQL, {'galaxy': int(galaxy)})
 	row = cursor.fetchone()
 	while row != None:
 		listHTML += '<option value="{0}">{1}</option>'.format(row[0], row[1])

--- a/html/galaxy.py
+++ b/html/galaxy.py
@@ -63,14 +63,14 @@ def getElectiveResourceTypeList(conn, galaxy, available):
 			tResourceType.resourceType,
 			resourceTypeName
 		FROM tResourceType
-			LEFT JOIN tGalaxyResourceType tgrt ON tgrt.resourceType = tResourceType.resourceType AND tgrt.galaxyID = {0}
+			LEFT JOIN tGalaxyResourceType tgrt ON tgrt.resourceType = tResourceType.resourceType AND tgrt.galaxyID = %(galaxy)s
 		WHERE
-			elective = 1 AND tgrt.resourceType {1}
+			elective = 1 AND tgrt.resourceType {0}
 		ORDER BY resourceTypeName;
-	""".format(galaxy, is_or_is_not_null)
+	""".format(is_or_is_not_null)
 
 	cursor = conn.cursor()
-	cursor.execute(resourceTypeSQL)
+	cursor.execute(resourceTypeSQL, {'galaxy': galaxy})
 	row = cursor.fetchone()
 	while row != None:
 		listHTML += '<option value="{0}">{1}</option>'.format(row[0], row[1])

--- a/html/galaxy.py
+++ b/html/galaxy.py
@@ -70,7 +70,7 @@ def getElectiveResourceTypeList(conn, galaxy, available):
 	""".format(is_or_is_not_null)
 
 	cursor = conn.cursor()
-	cursor.execute(resourceTypeSQL, {'galaxy': int(galaxy)})
+	cursor.execute(resourceTypeSQL, {'galaxy': ghShared.tryInt(galaxy)})
 	row = cursor.fetchone()
 	while row != None:
 		listHTML += '<option value="{0}">{1}</option>'.format(row[0], row[1])

--- a/html/getCreatureResourceGroups.py
+++ b/html/getCreatureResourceGroups.py
@@ -49,12 +49,14 @@ if (cursor):
          tResourceGroup.containerType
     FROM tResourceGroup
       INNER JOIN tResourceType ON tResourceType.resourceGroup = tResourceGroup.resourceGroup
+      LEFT JOIN tGalaxyResourceType tgrt ON tgrt.resourceType = tResourceType.resourceType AND tgrt.galaxyID={0}
       INNER JOIN tResourceTypeCreature ON tResourceTypeCreature.resourceType = tResourceType.resourceType
     WHERE tResourceGroup.containerType IN ('bone', 'hide', 'meat', 'milk')
       AND tResourceTypeCreature.galaxy IN (0, %s)
+      AND (tResourceType.elective = 0 OR tgrt.resourceType IS NOT NULL)
     GROUP BY tResourceGroup.resourceGroup
     ORDER BY tResourceGroup.resourceGroup
-  """
+  """.format(galaxy)
 
   # Execute SQL and fetch first row
   cursor.execute(sqlStr, (galaxy,))

--- a/html/getCreatureResourceGroups.py
+++ b/html/getCreatureResourceGroups.py
@@ -38,9 +38,6 @@ galaxy = dbShared.dbInsertSafe(galaxy)
 clist = ''
 containerType = ''
 
-if galaxy.isdigit():
-  galaxy = int(galaxy)
-
 conn = dbShared.ghConn()
 cursor = conn.cursor()
 
@@ -62,7 +59,7 @@ if (cursor):
   """
 
   # Execute SQL and fetch first row
-  cursor.execute(sqlStr, {'galaxy': galaxy})
+  cursor.execute(sqlStr, {'galaxy': ghShared.tryInt(galaxy)})
   row = cursor.fetchone()
 
   clist += '<ul class="schematics">'

--- a/html/getCreatureResourceGroups.py
+++ b/html/getCreatureResourceGroups.py
@@ -38,6 +38,9 @@ galaxy = dbShared.dbInsertSafe(galaxy)
 clist = ''
 containerType = ''
 
+if galaxy.isdigit():
+  galaxy = int(galaxy)
+
 conn = dbShared.ghConn()
 cursor = conn.cursor()
 

--- a/html/getCreatureResourceGroups.py
+++ b/html/getCreatureResourceGroups.py
@@ -49,17 +49,17 @@ if (cursor):
          tResourceGroup.containerType
     FROM tResourceGroup
       INNER JOIN tResourceType ON tResourceType.resourceGroup = tResourceGroup.resourceGroup
-      LEFT JOIN tGalaxyResourceType tgrt ON tgrt.resourceType = tResourceType.resourceType AND tgrt.galaxyID={0}
+      LEFT JOIN tGalaxyResourceType tgrt ON tgrt.resourceType = tResourceType.resourceType AND tgrt.galaxyID=%(galaxy)s
       INNER JOIN tResourceTypeCreature ON tResourceTypeCreature.resourceType = tResourceType.resourceType
     WHERE tResourceGroup.containerType IN ('bone', 'hide', 'meat', 'milk')
-      AND tResourceTypeCreature.galaxy IN (0, %s)
+      AND tResourceTypeCreature.galaxy IN (0, %(galaxy)s)
       AND (tResourceType.elective = 0 OR tgrt.resourceType IS NOT NULL)
     GROUP BY tResourceGroup.resourceGroup
     ORDER BY tResourceGroup.resourceGroup
-  """.format(galaxy)
+  """
 
   # Execute SQL and fetch first row
-  cursor.execute(sqlStr, (galaxy,))
+  cursor.execute(sqlStr, {'galaxy': galaxy})
   row = cursor.fetchone()
 
   clist += '<ul class="schematics">'

--- a/html/getResourceTypeList.py
+++ b/html/getResourceTypeList.py
@@ -50,9 +50,11 @@ else:
 	criteriaStr = ''
 
 if planetID.isdigit() and int(planetID) > 0:
+	planetID = int(planetID)
 	criteriaStr = criteriaStr + ' AND (specificPlanet = 0 OR specificPlanet = %(planetID)s)'
 else:
 	if galaxy.isdigit() and int(galaxy) > 0:
+		galaxy = int(galaxy)
 		criteriaStr = criteriaStr + ' AND (specificPlanet = 0 OR specificPlanet IN (SELECT DISTINCT tPlanet.planetID FROM tPlanet, tGalaxyPlanet WHERE (tPlanet.planetID < 11) OR (tPlanet.planetID = tGalaxyPlanet.planetID AND tGalaxyPlanet.galaxyID = %(galaxy)s)))'
 
 conn = dbShared.ghConn()

--- a/html/getResourceTypeList.py
+++ b/html/getResourceTypeList.py
@@ -45,15 +45,15 @@ else:
 	print('<option value="none" title="p00000000000">None</option>')
 
 if len(resGroup) > 0:
-	criteriaStr = 'AND (resourceGroup = "{0}" OR resourceCategory = "{0}")'.format(resGroup)
+	criteriaStr = 'AND (resourceGroup = %(resGroup)s OR resourceCategory = %(resGroup)s)'
 else:
 	criteriaStr = ''
 
 if planetID.isdigit() and int(planetID) > 0:
-	criteriaStr = criteriaStr + ' AND (specificPlanet = 0 OR specificPlanet = {0})'.format(planetID)
+	criteriaStr = criteriaStr + ' AND (specificPlanet = 0 OR specificPlanet = %(planetID)s)'
 else:
 	if galaxy.isdigit() and int(galaxy) > 0:
-		criteriaStr = criteriaStr + ' AND (specificPlanet = 0 OR specificPlanet IN (SELECT DISTINCT tPlanet.planetID FROM tPlanet, tGalaxyPlanet WHERE (tPlanet.planetID < 11) OR (tPlanet.planetID = tGalaxyPlanet.planetID AND tGalaxyPlanet.galaxyID = {0})))'.format(galaxy)
+		criteriaStr = criteriaStr + ' AND (specificPlanet = 0 OR specificPlanet IN (SELECT DISTINCT tPlanet.planetID FROM tPlanet, tGalaxyPlanet WHERE (tPlanet.planetID < 11) OR (tPlanet.planetID = tGalaxyPlanet.planetID AND tGalaxyPlanet.galaxyID = %(galaxy)s)))'
 
 conn = dbShared.ghConn()
 cursor = conn.cursor()
@@ -79,12 +79,12 @@ if (cursor):
 			containerType
 		FROM
 			tResourceType
-			LEFT JOIN tGalaxyResourceType tgrt ON tgrt.resourceType = tResourceType.resourceType AND tgrt.galaxyID = {0}
-		WHERE enterable>0 {1} AND (elective = 0 OR tgrt.resourceType IS NOT NULL)
+			LEFT JOIN tGalaxyResourceType tgrt ON tgrt.resourceType = tResourceType.resourceType AND tgrt.galaxyID = %(galaxy)s
+		WHERE enterable>0 {0} AND (elective = 0 OR tgrt.resourceType IS NOT NULL)
 		ORDER BY resourceTypeName;
-	""".format(galaxy, criteriaStr)
+	""".format(criteriaStr)
 
-	cursor.execute(sqlString)
+	cursor.execute(sqlString, {'resGroup': resGroup, 'planetID': planetID, 'galaxy': galaxy})
 	row = cursor.fetchone()
 	if row == None and len(resGroup) > 0:
 		cursor.execute('select rgc.resourceGroup, rg.groupName, "p11111111111" AS statMask, containerType FROM tResourceGroupCategory rgc INNER JOIN tResourceGroup rg ON rgc.resourceGroup = rg.resourceGroup WHERE rgc.resourceCategory="' + resGroup + '";')

--- a/html/getResourceTypeList.py
+++ b/html/getResourceTypeList.py
@@ -50,11 +50,9 @@ else:
 	criteriaStr = ''
 
 if planetID.isdigit() and int(planetID) > 0:
-	planetID = int(planetID)
 	criteriaStr = criteriaStr + ' AND (specificPlanet = 0 OR specificPlanet = %(planetID)s)'
 else:
 	if galaxy.isdigit() and int(galaxy) > 0:
-		galaxy = int(galaxy)
 		criteriaStr = criteriaStr + ' AND (specificPlanet = 0 OR specificPlanet IN (SELECT DISTINCT tPlanet.planetID FROM tPlanet, tGalaxyPlanet WHERE (tPlanet.planetID < 11) OR (tPlanet.planetID = tGalaxyPlanet.planetID AND tGalaxyPlanet.galaxyID = %(galaxy)s)))'
 
 conn = dbShared.ghConn()
@@ -86,7 +84,12 @@ if (cursor):
 		ORDER BY resourceTypeName;
 	""".format(criteriaStr)
 
-	cursor.execute(sqlString, {'resGroup': resGroup, 'planetID': planetID, 'galaxy': galaxy})
+	cursor.execute(sqlString, {
+		'galaxy': ghShared.tryInt(galaxy),
+		'planetID': ghShared.tryInt(planetID),
+		'resGroup': resGroup
+	})
+
 	row = cursor.fetchone()
 	if row == None and len(resGroup) > 0:
 		cursor.execute('select rgc.resourceGroup, rg.groupName, "p11111111111" AS statMask, containerType FROM tResourceGroupCategory rgc INNER JOIN tResourceGroup rg ON rgc.resourceGroup = rg.resourceGroup WHERE rgc.resourceCategory="' + resGroup + '";')

--- a/html/ghHome.py
+++ b/html/ghHome.py
@@ -76,6 +76,7 @@ else:
 
 # escape input to prevent sql injection
 sid = dbShared.dbInsertSafe(sid)
+galaxy = dbShared.dbInsertSafe(galaxy)
 
 # Get a session
 logged_state = 0

--- a/html/ghLists.py
+++ b/html/ghLists.py
@@ -118,7 +118,27 @@ def getOptionList(sqlStr):
 
 def getResourceTypeList(galaxy='-1'):
 	if galaxy != '-1':
-		listStr = getOptionList('SELECT resourceType, resourceTypeName FROM tResourceType WHERE (specificPlanet = 0 OR specificPlanet IN (SELECT DISTINCT tPlanet.planetID FROM tPlanet, tGalaxyPlanet WHERE (tPlanet.planetID < 11) OR (tPlanet.planetID = tGalaxyPlanet.planetID AND tGalaxyPlanet.galaxyID = {0})))'.format(galaxy) + ' ORDER BY resourceTypeName;')
+		sqlStr = """
+			SELECT
+				tResourceType.resourceType,
+				resourceTypeName
+			FROM
+				tResourceType
+				LEFT JOIN tGalaxyResourceType tgrt ON tgrt.resourceType = tResourceType.resourceType AND tgrt.galaxyID = {0}
+			WHERE
+				(
+					specificPlanet = 0
+					OR specificPlanet IN (
+						SELECT
+							DISTINCT tPlanet.planetID
+						FROM tPlanet, tGalaxyPlanet
+						WHERE (tPlanet.planetID < 11) OR (tPlanet.planetID = tGalaxyPlanet.planetID AND tGalaxyPlanet.galaxyID = {0})
+					)
+				) AND (elective = 0 OR tgrt.resourceType IS NOT NULL)
+			ORDER BY resourceTypeName;
+		""".format(galaxy)
+
+		listStr = getOptionList(sqlStr)
 	else:
 		listStr = getOptionList('SELECT resourceType, resourceTypeName FROM tResourceType ORDER BY resourceTypeName;')
 	return listStr

--- a/html/ghShared.py
+++ b/html/ghShared.py
@@ -151,9 +151,9 @@ def getMobilePlatform(agentString):
 
 def tryInt(v):
 	try:
-		int(v)
+		return int(v)
 	except:
-		v
+		return v
 
 # Translation of schematic event types to names
 SCHEMATIC_EVENT_NAMES = {'a': 'Added',

--- a/html/ghShared.py
+++ b/html/ghShared.py
@@ -149,6 +149,12 @@ def getMobilePlatform(agentString):
 
 	return mobilePlatform
 
+def tryInt(v):
+	try:
+		int(v)
+	except:
+		v
+
 # Translation of schematic event types to names
 SCHEMATIC_EVENT_NAMES = {'a': 'Added',
                 'e': 'Edited',

--- a/html/schematics.py
+++ b/html/schematics.py
@@ -237,7 +237,8 @@ def main():
 								tmpName = ingRow[4]
 								tmpLink = '<a href="' + ghShared.BASE_SCRIPT_URL + 'resourceType.py/' + ingRow[2] + '">' + tmpName + '</a>'
 							else:
-								tmpLink = '<a href="' + ghShared.BASE_SCRIPT_URL + 'resourceType.py/' + ingRow[2] + '">' + tmpName + '</a>'
+								tmpName = "Unknown Ingredient"
+								tmpLink = f"[{tmpName}]"
 						else:
 							# component
 							results = getComponentLink(conn, tmpObject, ingRow[1]).split('|')

--- a/html/templates/galaxy.html
+++ b/html/templates/galaxy.html
@@ -45,21 +45,57 @@ function removePlanets() {
     this.remove();
   });
 }
+// Managed resource type list functions
+function addResourceTypes() {
+  if ($("#resourceTypesAvailable > option:selected").length > 0) {
+    $("#resourceTypesSelected > option:selected").removeAttr('selected');
+  }
+
+  $("#resourceTypesAvailable > option:selected").each(function() {
+    $("#resourceTypesSelected").append(this).html(
+      $('#resourceTypesSelected > option').sort(function(a, b) {
+        return a.text.localeCompare(b.text);
+      })
+    );
+  });
+}
+function removeResourceTypes() {
+  if ($("#resourceTypesSelected > option:selected").length > 0) {
+    $("#resourceTypesAvailable > option:selected").removeAttr('selected');
+  }
+
+  $("#resourceTypesSelected > option:selected").each(function() {
+    $("#resourceTypesAvailable").append(this).html(
+      $('#resourceTypesAvailable > option').sort(function(a, b) {
+        return a.text.localeCompare(b.text);
+      })
+    );
+  });
+}
 // Send galaxy details
 function saveGalaxy() {
   $('#busyImgSave').css('display','block');
+
   // build comma separated list of planets.
   var planets = '';
   $('#planetsSelected > option').each(function() {
     planets += ($(this).attr('value') + ',');
   });
+
+  // build comma separated list of resource types.
+  var resourceTypes = '';
+  $('#resourceTypesSelected > option').each(function() {
+    resourceTypes += ($(this).attr('value') + ',');
+  });
+
   // build list of admin users.
   var admins = '';
   $('#adminUsers > div').each(function() {
     admins += ($(this).text() + ',');
   });
+
   // send data
-  $.post(BASE_SCRIPT_URL + 'postGalaxy.py', { galaxyID: '{{ galaxyID }}', galaxyName: $('#galaxyName').val(), galaxyState: $('#galaxyStatus').val(), galaxyNGE: $('#oGalaxyNGE').attr('checked'), galaxyWebsite: $('#galaxyWebsite').val(), galaxyPlanets: planets, galaxyAdmins: admins },
+  $.post(BASE_SCRIPT_URL + 'postGalaxy.py', { galaxyID: '{{ galaxyID }}', galaxyName: $('#galaxyName').val(), galaxyState: $('#galaxyStatus').val(), galaxyNGE: $('#oGalaxyNGE').attr('checked'), galaxyWebsite: $('#galaxyWebsite').val(), galaxyPlanets: planets, galaxyResourceTypes: resourceTypes, galaxyAdmins: admins },
     function(data) {
       var result = $(data).find('resultText').eq(0).text();
       $('#busyImgSave').css('display','none');
@@ -94,9 +130,27 @@ function saveGalaxy() {
           <tr><td><div title="Please enter the web address where people can go to get info on how to sign up and play on your server.">Website:</div></td><td colspan="2"><input type="text" id="galaxyWebsite" size="40" maxlength="1023" value="{{ galaxyWebsite }}"/></td></tr>
           <tr><td colspan=3><h3 title="If your server has additional planets where players can collect resources, add them here.">Extra Planets:</h3></td></tr>
           <tr>
-            <td>Available:<br/><select multiple size="12" id="planetsAvailable" style="min-width: 120px;">{{ availablePlanetList }}</select></td>
-            <td align="center"><input type="button" class="ghButton planetButton" value="Add    -&gt;" onclick="addPlanets();"></input><br/><br/><input type="button" class="ghButton planetButton" value="&lt;- Remove" onclick="removePlanets();"></input></td>
-            <td>Selected:<br/><select multiple size="12" id="planetsSelected" style="min-width: 120px;">{{ galaxyPlanetList }}</select></td>
+            <td colspan="3">
+              <table>
+                <tr>
+                  <td>Available:<br/><select multiple size="12" id="planetsAvailable" style="min-width: 120px;">{{ availablePlanetList }}</select></td>
+                  <td align="center"><input type="button" class="ghButton planetButton" value="Add    -&gt;" onclick="addPlanets();"></input><br/><br/><input type="button" class="ghButton planetButton" value="&lt;- Remove" onclick="removePlanets();"></input></td>
+                  <td>Selected:<br/><select multiple size="12" id="planetsSelected" style="min-width: 120px;">{{ galaxyPlanetList }}</select></td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr><td colspan=3><h3 title="If your server has additional resource types, add them here.">Extra Resource Types:</h3></td></tr>
+          <tr>
+            <td colspan="3">
+              <table>
+                <tr>
+                  <td>Available:<br/><select multiple size="12" id="resourceTypesAvailable" style="min-width: 120px;">{{ availableResourceTypeList }}</select></td>
+                  <td align="center"><input type="button" class="ghButton" value="Add    -&gt;" onclick="addResourceTypes();"></input><br/><br/><input type="button" class="ghButton" value="&lt;- Remove" onclick="removeResourceTypes();"></input></td>
+                  <td>Selected:<br/><select multiple size="12" id="resourceTypesSelected" style="min-width: 120px;">{{ galaxyResourceTypeList }}</select></td>
+                </tr>
+              </table>
+            </td>
           </tr>
           <tr><td><div title="List any Galaxy Harvester users that should be able to come to this screen and edit this galaxy's details.">Galaxy Admins:</div></td><td colspan="2"></td></tr>
           <tr><td colspan="3"><div id="adminUsers" class="inlineItemBlockList"><input id="adminUserAdd" type="text" size="12" />


### PR DESCRIPTION
## Context

On Empire in Flames (`galaxyID: 64`), we have four custom resource types that spawn. As far as I know, these resources have been spawning for years and have been uploaded to the GalaxyHarvester database. However, because the types don't exist in the `tResourceType` table, the associated resources are never reported on, nor are they accessible in the galaxy harvester UI.

We want to be able to create alerts and figure out which of these resources are server bests.

## Approach

The implementation relies on four things:

1. A new `elective` column in the `tResourceType` table. This value defaults to `0` (i.e. "false") and means none of the base types are elective. When a resource is "elective", it means that a galaxy admin must opt-in to including it (similar to planets)
2. A new `tGalaxyResourceType` table that represents the link between a galaxy and an elective resource type.
3. A galaxy admin UI for managing elective resource types
4. An incremental SQL script responsible for creating the four custom types as elective, including the necessary associations (e.g. `tResourceTypeGroup` mappings) and the default stat ranges.

![image](https://github.com/user-attachments/assets/90ebb85d-34e9-4f39-915c-70e6add3511e)


## Implementation Notes

- The four elective resource types are:
    + Mandalorian Type 1 Crystal Amorphous Gem
    + Mandalorian Type 2 Crystal Amorphous Gem
    + Mandalorian Type 1 Crystalline Gem
    + Mandalorian Type 2 Crystalline Gem
- Elective types will not be included by default. Galaxies must opt-in to using them.
- The primary key of `tGalaxyResourceType` is a compound key using both `galaxyID` and `resourceType`, which ensures that we don't allow for duplicate entries per galaxy.

---

## Misc. Changes

- updated some SQL executions to use a dict of parameters, which allows for named sql parameters rather than positional ones
- fixes a bug where a schematic can't be loaded if any of its ingredients don't exist in the database
- added a helper function `tryInt` in `ghShared.py` that accepts any value and either
    + returns it casted as an integer (if possible) or returns the original value (if an exception is raised, i.e. the value can't be casted as an integer)
    + this function is primarily used for `planetID` and `galaxyID` params to set the data type _before_ referencing it in a query, ensuring we have the correct data type instead of relying on MySQL to lazily cast it for us every time 