### PR TITLE
plausible initial planet for new resource waypoint

### DIFF
--- a/html/js/ghShared.js
+++ b/html/js/ghShared.js
@@ -589,7 +589,7 @@ function planetRemove(linkFrom, planet, spawn, planetName) {
 	}
 
 }
-function loadPlanetSel(galaxy, optionZero, elmSelector) {
+function loadPlanetSel(galaxy, optionZero, elmSelector, selected="") {
   var planetOptions = optionZero || '';
   var elmSelector = elmSelector || '#planetSel'
   // Fetch planet data and load into html select elm
@@ -601,6 +601,7 @@ function loadPlanetSel(galaxy, optionZero, elmSelector) {
           planetOptions = planetOptions + '<option value=' + $(planetIds).find('item').eq(i).text() + '>' + $(planetNames).find('item').eq(i).text() + '</option>';
       }
       $(elmSelector).html(planetOptions);
+      $(elmSelector).val(selected);
     }, "xml");
   return;
 }

--- a/html/resource.py
+++ b/html/resource.py
@@ -24,6 +24,7 @@ import os
 import sys
 import cgi
 from http import cookies
+import json
 import dbSession
 import dbShared
 import pymysql
@@ -166,6 +167,7 @@ def main():
 	galaxyState = 0
 	userReputation = 0
 	admin = False
+	availablePlanetIDs = []
 	# Get current url
 	try:
 		url = os.environ['SCRIPT_NAME']
@@ -260,8 +262,8 @@ def main():
 				else:
 					controlsUser = ''
 
+				availablePlanetIDs = [str(p.planetID) for p in spawn.planets if p.enteredBy != None]
 				resHTML = spawn.getHTML(0, "", controlsUser, userReputation, admin)
-
 				resHistory = getResourceHistory(conn, spawn.spawnID)
 			conn.close()
 		else:
@@ -276,7 +278,7 @@ def main():
 	env.globals['BASE_SCRIPT_URL'] = ghShared.BASE_SCRIPT_URL
 	env.globals['MOBILE_PLATFORM'] = ghShared.getMobilePlatform(os.environ['HTTP_USER_AGENT'])
 	template = env.get_template('resource.html')
-	print(template.render(uiTheme=uiTheme, loggedin=logged_state, currentUser=currentUser, loginResult=loginResult, linkappend=linkappend, url=url, pictureName=pictureName, imgNum=ghShared.imgNum, galaxyList=ghLists.getGalaxyList(), spawnName=spawnName, resHTML=resHTML, resHistory=resHistory, showAdmin=(userReputation >= ghShared.MIN_REP_VALS['EDIT_RESOURCE_GALAXY_NAME'] or admin), spawnID=spawnID, spawnGalaxy=galaxy, spawnStats=spawnStats, spawnContainerType=spawnContainerType, spawnResourceTypeName=spawnResourceTypeName, enableCAPTCHA=ghShared.RECAPTCHA_ENABLED, siteidCAPTCHA=ghShared.RECAPTCHA_SITEID))
+	print(template.render(uiTheme=uiTheme, loggedin=logged_state, currentUser=currentUser, loginResult=loginResult, linkappend=linkappend, url=url, pictureName=pictureName, imgNum=ghShared.imgNum, galaxyList=ghLists.getGalaxyList(), spawnName=spawnName, availablePlanetIDsJSON=json.dumps(availablePlanetIDs), resHTML=resHTML, resHistory=resHistory, showAdmin=(userReputation >= ghShared.MIN_REP_VALS['EDIT_RESOURCE_GALAXY_NAME'] or admin), spawnID=spawnID, spawnGalaxy=galaxy, spawnStats=spawnStats, spawnContainerType=spawnContainerType, spawnResourceTypeName=spawnResourceTypeName, enableCAPTCHA=ghShared.RECAPTCHA_ENABLED, siteidCAPTCHA=ghShared.RECAPTCHA_SITEID))
 
 
 if __name__ == "__main__":

--- a/html/templates/resource.html
+++ b/html/templates/resource.html
@@ -26,7 +26,11 @@ $(document).ready(function() {
       { spawnID: {{ spawnID }} },
       function(){$("#busyImgServerBest").css("display","none");}
     );
-    loadPlanetSel($("#galaxySel option:selected").val(), '', '#wpPlanetSel');
+
+    const availablePlanetIDs = {{ availablePlanetIDsJSON }};
+    defaultSelectedPlanet = availablePlanetIDs.length > 0 ? availablePlanetIDs[0] : ""
+
+    loadPlanetSel($("#galaxySel option:selected").val(), '', '#wpPlanetSel', defaultSelectedPlanet);
 });
 function saveAdmin() {
     var newName = document.getElementById("newResourceName").value;


### PR DESCRIPTION
## CONTEXT

On a given resource page, there's a link to create a new waypoint that opens a form in a a modal. One of the steps in this process is loading all of the planet values and populating the dropdown. The dropdown then always has the first value selected.

For example:

<img width="813" alt="baseline" src="https://github.com/user-attachments/assets/0c8bd86d-c0af-40bf-a17b-c1f653c9fe38" />

In the example above, we can see that the only planet that this resource is available on is Dantooine. When we click the "Add Waypoint" button, the default selected planet is "Corellia" because it is first in the list.

<img width="273" alt="current" src="https://github.com/user-attachments/assets/94a711f5-3127-4ac8-9a16-da2a139887bb" />

## PROPOSAL

> The idea for these changes comes from feedback via conversation with Axims / "Shock" (another player on Empire in Flames)

Since we know which planets the resource is available on, we can help the user out a bit by setting the initial value as the first planet where the resource is available (if any).

Therefore, if there are any available planets it will select the first one. Otherwise, it will use the same behavior that already exists.

Referring back to the example above, with the new logic we would pre-select "Dantooine".

<img width="276" alt="new" src="https://github.com/user-attachments/assets/0ee3a087-caab-437f-b6df-b60289f20fd8" />