### PR TITLE
[fix] apply overrides when fetching resource types for galaxy

### DIFF
--- a/html/ghLists.py
+++ b/html/ghLists.py
@@ -125,10 +125,11 @@ def getResourceTypeList(galaxy='-1'):
 			FROM
 				tResourceType
 				LEFT JOIN tGalaxyResourceType tgrt ON tgrt.resourceType = tResourceType.resourceType AND tgrt.galaxyID = {0}
+				LEFT JOIN tResourceTypeOverrides trto ON trto.resourceType = tResourceType.resourceType AND trto.galaxyID = {0}
 			WHERE
 				(
-					specificPlanet = 0
-					OR specificPlanet IN (
+					COALESCE(trto.specificPlanet, tResourceType.specificPlanet) = 0
+					OR COALESCE(trto.specificPlanet, tResourceType.specificPlanet) IN (
 						SELECT
 							DISTINCT tPlanet.planetID
 						FROM tPlanet, tGalaxyPlanet


### PR DESCRIPTION
## CONTEXT

After #79 was merged, another player did some testing and pointed out that the overrides were not showing up in certain areas of the site, most notably:

- "Quick Search" on the Home page
- "Res Type" on the List page
- "Res Type" on the Find page

## APPROACH

Apply the same logic from `getResourceTypeList.py` to the function `getResourceTypeList/1` in `ghLists.py`